### PR TITLE
refactor: migrate inline Tailwind to CSS modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,6 @@ jobs:
 
       - name: Format check
         run: bun run format:check
+
+      - name: Build
+        run: bun run build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,3 +166,75 @@ bunx shadcn@latest add <component-name>
 - Use `cn()` utility for conditional/merged Tailwind classes
 - Components use Radix UI primitives for accessibility
 - Customize by editing the component source directly
+
+### CSS Modules with Tailwind
+
+Custom components use **CSS modules** with Tailwind's `@apply` directive for better separation of concerns and maintainability.
+
+**File structure pattern:**
+```
+ComponentName/
+  ComponentName.tsx
+  ComponentName.module.css
+  index.ts (barrel export)
+```
+
+**CSS module setup:**
+
+All CSS modules **must** include the `@reference` directive at the top to access Tailwind utilities:
+
+```css
+@reference "~/styles/app.css";
+
+.container {
+  @apply flex items-center gap-2 p-4;
+}
+
+.title {
+  @apply text-2xl font-semibold;
+}
+```
+
+**Usage in components:**
+
+```tsx
+import styles from "./ComponentName.module.css";
+
+export function ComponentName() {
+  return (
+    <div className={styles.container}>
+      <h1 className={styles.title}>Title</h1>
+    </div>
+  );
+}
+```
+
+**When to use CSS modules:**
+
+- ✅ Custom components with multiple elements and consistent styling
+- ✅ Repeated style patterns across a component
+- ✅ Complex layouts that benefit from semantic class names
+- ❌ shadcn/ui components (keep inline Tailwind)
+- ❌ One-off styles or simple utility classes
+- ❌ Highly dynamic styles that change frequently
+
+**Dynamic classes with cn():**
+
+For conditional/dynamic styling, combine CSS module classes with `cn()`:
+
+```tsx
+import { cn } from "~/lib/utils";
+import styles from "./Message.module.css";
+
+<div className={cn(
+  styles.messageBubble,
+  message.role === "user" ? styles.userMessage : styles.assistantMessage
+)} />
+```
+
+**Important notes:**
+
+- Use `@reference "~/styles/app.css"` (~ alias configured in vite.config.ts)
+- Use **semantic naming** (`.container`, `.header`, `.actionButton`)
+- Keep CSS modules **co-located** with components
+- Export components via `index.ts` barrel files for clean imports

--- a/src/components/DefaultCatchBoundary/DefaultCatchBoundary.module.css
+++ b/src/components/DefaultCatchBoundary/DefaultCatchBoundary.module.css
@@ -1,0 +1,13 @@
+@reference "../../styles/app.css";
+
+.container {
+  @apply min-w-0 flex-1 p-4 flex flex-col items-center justify-center gap-6;
+}
+
+.actions {
+  @apply flex gap-2 items-center flex-wrap;
+}
+
+.actionButton {
+  @apply px-2 py-1 bg-gray-600 dark:bg-gray-700 rounded-sm text-white uppercase font-extrabold;
+}

--- a/src/components/DefaultCatchBoundary/DefaultCatchBoundary.module.css
+++ b/src/components/DefaultCatchBoundary/DefaultCatchBoundary.module.css
@@ -1,4 +1,4 @@
-@reference "../../styles/app.css";
+@reference "~/styles/app.css";
 
 .container {
   @apply min-w-0 flex-1 p-4 flex flex-col items-center justify-center gap-6;

--- a/src/components/DefaultCatchBoundary/DefaultCatchBoundary.tsx
+++ b/src/components/DefaultCatchBoundary/DefaultCatchBoundary.tsx
@@ -24,10 +24,7 @@ export function DefaultCatchBoundary({ error }: ErrorComponentProps) {
           Try Again
         </button>
         {isRoot ? (
-          <Link
-            to="/"
-            className={styles.actionButton}
-          >
+          <Link to="/" className={styles.actionButton}>
             Home
           </Link>
         ) : (

--- a/src/components/DefaultCatchBoundary/DefaultCatchBoundary.tsx
+++ b/src/components/DefaultCatchBoundary/DefaultCatchBoundary.tsx
@@ -1,5 +1,6 @@
 import { ErrorComponent, Link, rootRouteId, useMatch, useRouter } from "@tanstack/react-router";
 import type { ErrorComponentProps } from "@tanstack/react-router";
+import styles from "./DefaultCatchBoundary.module.css";
 
 export function DefaultCatchBoundary({ error }: ErrorComponentProps) {
   const router = useRouter();
@@ -11,28 +12,28 @@ export function DefaultCatchBoundary({ error }: ErrorComponentProps) {
   console.error("DefaultCatchBoundary Error:", error);
 
   return (
-    <div className="min-w-0 flex-1 p-4 flex flex-col items-center justify-center gap-6">
+    <div className={styles.container}>
       <ErrorComponent error={error} />
-      <div className="flex gap-2 items-center flex-wrap">
+      <div className={styles.actions}>
         <button
           onClick={() => {
             router.invalidate();
           }}
-          className={`px-2 py-1 bg-gray-600 dark:bg-gray-700 rounded-sm text-white uppercase font-extrabold`}
+          className={styles.actionButton}
         >
           Try Again
         </button>
         {isRoot ? (
           <Link
             to="/"
-            className={`px-2 py-1 bg-gray-600 dark:bg-gray-700 rounded-sm text-white uppercase font-extrabold`}
+            className={styles.actionButton}
           >
             Home
           </Link>
         ) : (
           <Link
             to="/"
-            className={`px-2 py-1 bg-gray-600 dark:bg-gray-700 rounded-sm text-white uppercase font-extrabold`}
+            className={styles.actionButton}
             onClick={(e) => {
               e.preventDefault();
               window.history.back();

--- a/src/components/DefaultCatchBoundary/index.ts
+++ b/src/components/DefaultCatchBoundary/index.ts
@@ -1,0 +1,1 @@
+export { DefaultCatchBoundary } from "./DefaultCatchBoundary";

--- a/src/components/LoginForm/LoginForm.module.css
+++ b/src/components/LoginForm/LoginForm.module.css
@@ -1,4 +1,4 @@
-@reference "../../styles/app.css";
+@reference "~/styles/app.css";
 
 .page {
   @apply flex min-h-svh w-full items-center justify-center p-6 md:p-10;

--- a/src/components/LoginForm/LoginForm.module.css
+++ b/src/components/LoginForm/LoginForm.module.css
@@ -1,0 +1,25 @@
+@reference "../../styles/app.css";
+
+.page {
+  @apply flex min-h-svh w-full items-center justify-center p-6 md:p-10;
+}
+
+.cardContainer {
+  @apply w-full max-w-sm;
+}
+
+.cardTitle {
+  @apply text-2xl;
+}
+
+.fieldError {
+  @apply text-sm text-red-500 mt-1;
+}
+
+.submitButton {
+  @apply w-full;
+}
+
+.formError {
+  @apply text-sm text-red-500 mt-2 text-center;
+}

--- a/src/components/LoginForm/LoginForm.tsx
+++ b/src/components/LoginForm/LoginForm.tsx
@@ -7,6 +7,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "~/com
 import { Field, FieldGroup, FieldLabel } from "~/components/ui/field";
 import { Input } from "~/components/ui/input";
 import { loginFn } from "~/routes/_authed";
+import styles from "./LoginForm.module.css";
 
 const loginSchema = z.object({
   email: z.string().email("Invalid email address"),
@@ -42,11 +43,11 @@ export function LoginForm() {
   });
 
   return (
-    <div className="flex min-h-svh w-full items-center justify-center p-6 md:p-10">
-      <div className="w-full max-w-sm">
+    <div className={styles.page}>
+      <div className={styles.cardContainer}>
         <Card>
           <CardHeader>
-            <CardTitle className="text-2xl">Login to your account</CardTitle>
+            <CardTitle className={styles.cardTitle}>Login to your account</CardTitle>
             <CardDescription>Enter your email below to login to your account</CardDescription>
           </CardHeader>
           <CardContent>
@@ -71,7 +72,7 @@ export function LoginForm() {
                         onBlur={field.handleBlur}
                       />
                       {field.state.meta.errors.map((error, i) => (
-                        <p key={i} className="text-sm text-red-500 mt-1">
+                        <p key={i} className={styles.fieldError}>
                           {error?.message}
                         </p>
                       ))}
@@ -91,7 +92,7 @@ export function LoginForm() {
                         onBlur={field.handleBlur}
                       />
                       {field.state.meta.errors.map((error, i) => (
-                        <p key={i} className="text-sm text-red-500 mt-1">
+                        <p key={i} className={styles.fieldError}>
                           {error?.message}
                         </p>
                       ))}
@@ -103,7 +104,7 @@ export function LoginForm() {
                     {([canSubmit, isSubmitting]) => (
                       <Button
                         type="submit"
-                        className="w-full"
+                        className={styles.submitButton}
                         disabled={!canSubmit || isSubmitting}
                       >
                         {isSubmitting ? "Logging in..." : "Login"}
@@ -111,7 +112,7 @@ export function LoginForm() {
                     )}
                   </form.Subscribe>
                   {loginMutation.error && (
-                    <p className="text-sm text-red-500 mt-2 text-center">
+                    <p className={styles.formError}>
                       {loginMutation.error.message}
                     </p>
                   )}

--- a/src/components/LoginForm/LoginForm.tsx
+++ b/src/components/LoginForm/LoginForm.tsx
@@ -112,9 +112,7 @@ export function LoginForm() {
                     )}
                   </form.Subscribe>
                   {loginMutation.error && (
-                    <p className={styles.formError}>
-                      {loginMutation.error.message}
-                    </p>
+                    <p className={styles.formError}>{loginMutation.error.message}</p>
                   )}
                 </Field>
               </FieldGroup>

--- a/src/components/LoginForm/index.ts
+++ b/src/components/LoginForm/index.ts
@@ -1,0 +1,1 @@
+export { LoginForm } from "./LoginForm";

--- a/src/components/NotFound/NotFound.module.css
+++ b/src/components/NotFound/NotFound.module.css
@@ -1,0 +1,25 @@
+@reference "../../styles/app.css";
+
+.container {
+  @apply space-y-2 p-2;
+}
+
+.message {
+  @apply text-gray-600 dark:text-gray-400;
+}
+
+.actions {
+  @apply flex items-center gap-2 flex-wrap;
+}
+
+.actionButton {
+  @apply px-2 py-1 rounded-sm uppercase font-black text-sm text-white;
+}
+
+.goBackButton {
+  @apply bg-emerald-500;
+}
+
+.startOverButton {
+  @apply bg-cyan-600;
+}

--- a/src/components/NotFound/NotFound.module.css
+++ b/src/components/NotFound/NotFound.module.css
@@ -1,4 +1,4 @@
-@reference "../../styles/app.css";
+@reference "~/styles/app.css";
 
 .container {
   @apply space-y-2 p-2;

--- a/src/components/NotFound/NotFound.tsx
+++ b/src/components/NotFound/NotFound.tsx
@@ -14,10 +14,7 @@ export function NotFound({ children }: { children?: any }) {
         >
           Go back
         </button>
-        <Link
-          to="/"
-          className={`${styles.actionButton} ${styles.startOverButton}`}
-        >
+        <Link to="/" className={`${styles.actionButton} ${styles.startOverButton}`}>
           Start Over
         </Link>
       </p>

--- a/src/components/NotFound/NotFound.tsx
+++ b/src/components/NotFound/NotFound.tsx
@@ -1,21 +1,22 @@
 import { Link } from "@tanstack/react-router";
+import styles from "./NotFound.module.css";
 
 export function NotFound({ children }: { children?: any }) {
   return (
-    <div className="space-y-2 p-2">
-      <div className="text-gray-600 dark:text-gray-400">
+    <div className={styles.container}>
+      <div className={styles.message}>
         {children || <p>The page you are looking for does not exist.</p>}
       </div>
-      <p className="flex items-center gap-2 flex-wrap">
+      <p className={styles.actions}>
         <button
           onClick={() => window.history.back()}
-          className="bg-emerald-500 text-white px-2 py-1 rounded-sm uppercase font-black text-sm"
+          className={`${styles.actionButton} ${styles.goBackButton}`}
         >
           Go back
         </button>
         <Link
           to="/"
-          className="bg-cyan-600 text-white px-2 py-1 rounded-sm uppercase font-black text-sm"
+          className={`${styles.actionButton} ${styles.startOverButton}`}
         >
           Start Over
         </Link>

--- a/src/components/NotFound/index.ts
+++ b/src/components/NotFound/index.ts
@@ -1,0 +1,1 @@
+export { NotFound } from "./NotFound";

--- a/src/components/chat/ChatInput/ChatInput.module.css
+++ b/src/components/chat/ChatInput/ChatInput.module.css
@@ -1,4 +1,4 @@
-@reference "../../../styles/app.css";
+@reference "~/styles/app.css";
 
 .container {
   @apply border-t border-border bg-card;

--- a/src/components/chat/ChatInput/ChatInput.module.css
+++ b/src/components/chat/ChatInput/ChatInput.module.css
@@ -1,0 +1,21 @@
+@reference "../../../styles/app.css";
+
+.container {
+  @apply border-t border-border bg-card;
+}
+
+.inner {
+  @apply max-w-3xl mx-auto px-4 py-4;
+}
+
+.inputRow {
+  @apply flex gap-2 items-end;
+}
+
+.textarea {
+  @apply min-h-10 max-h-32 resize-none flex-1;
+}
+
+.sendButton {
+  @apply h-10 w-10 shrink-0;
+}

--- a/src/components/chat/ChatInput/ChatInput.tsx
+++ b/src/components/chat/ChatInput/ChatInput.tsx
@@ -4,6 +4,7 @@ import { Textarea } from "~/components/ui/textarea";
 import { Button } from "~/components/ui/button";
 import { Send } from "lucide-react";
 import { useIsMobile } from "~/hooks/use-mobile";
+import styles from "./ChatInput.module.css";
 
 const messageSchema = z.object({
   message: z.string().min(1, "Message cannot be empty"),
@@ -26,8 +27,8 @@ export function ChatInput({ onSend }: ChatInputProps) {
   });
 
   return (
-    <div className="border-t border-border bg-card">
-      <div className="max-w-3xl mx-auto px-4 py-4">
+    <div className={styles.container}>
+      <div className={styles.inner}>
         <form
           onSubmit={(e) => {
             e.preventDefault();
@@ -36,9 +37,9 @@ export function ChatInput({ onSend }: ChatInputProps) {
         >
           <form.Field name="message">
             {(field) => (
-              <div className="flex gap-2 items-end">
+              <div className={styles.inputRow}>
                 <Textarea
-                  className="min-h-10 max-h-32 resize-none flex-1"
+                  className={styles.textarea}
                   value={field.state.value}
                   placeholder={
                     isMobile
@@ -58,7 +59,7 @@ export function ChatInput({ onSend }: ChatInputProps) {
                   <Button
                     type="submit"
                     size="icon"
-                    className="h-10 w-10 shrink-0"
+                    className={styles.sendButton}
                     disabled={!field.state.value.trim()}
                   >
                     <Send className="h-4 w-4" />

--- a/src/components/chat/ChatInput/index.ts
+++ b/src/components/chat/ChatInput/index.ts
@@ -1,0 +1,1 @@
+export { ChatInput } from "./ChatInput";

--- a/src/components/chat/PromptPresets/PromptPresets.module.css
+++ b/src/components/chat/PromptPresets/PromptPresets.module.css
@@ -1,0 +1,9 @@
+@reference "../../../styles/app.css";
+
+.grid {
+  @apply flex flex-col sm:grid sm:grid-cols-2 gap-2 pt-4;
+}
+
+.presetButton {
+  @apply justify-start h-auto py-3 px-4;
+}

--- a/src/components/chat/PromptPresets/PromptPresets.module.css
+++ b/src/components/chat/PromptPresets/PromptPresets.module.css
@@ -1,4 +1,4 @@
-@reference "../../../styles/app.css";
+@reference "~/styles/app.css";
 
 .grid {
   @apply flex flex-col sm:grid sm:grid-cols-2 gap-2 pt-4;

--- a/src/components/chat/PromptPresets/PromptPresets.tsx
+++ b/src/components/chat/PromptPresets/PromptPresets.tsx
@@ -1,5 +1,6 @@
 import { Button } from "~/components/ui/button";
 import { JOURNAL_PRESETS } from "~/features/journal/presets";
+import styles from "./PromptPresets.module.css";
 
 interface PromptPresetsProps {
   onSelect: (message: string) => void;
@@ -7,12 +8,12 @@ interface PromptPresetsProps {
 
 export function PromptPresets({ onSelect }: PromptPresetsProps) {
   return (
-    <div className="flex flex-col sm:grid sm:grid-cols-2 gap-2 pt-4">
+    <div className={styles.grid}>
       {JOURNAL_PRESETS.map((preset) => (
         <Button
           key={preset.id}
           variant="outline"
-          className="justify-start h-auto py-3 px-4"
+          className={styles.presetButton}
           onClick={() => onSelect(preset.message)}
         >
           {preset.label}

--- a/src/components/chat/PromptPresets/index.ts
+++ b/src/components/chat/PromptPresets/index.ts
@@ -1,0 +1,1 @@
+export { PromptPresets } from "./PromptPresets";

--- a/src/components/chat/ToolInvocationDisplay/ToolInvocationDisplay.module.css
+++ b/src/components/chat/ToolInvocationDisplay/ToolInvocationDisplay.module.css
@@ -1,0 +1,73 @@
+@reference "../../../styles/app.css";
+
+.statusRow {
+  @apply flex items-center gap-2 text-sm py-2;
+}
+
+.icon {
+  @apply size-4;
+}
+
+.spinningIcon {
+  @apply size-4 animate-spin;
+}
+
+.loadingText {
+  @apply text-muted-foreground;
+}
+
+.errorText {
+  @apply text-red-500;
+}
+
+.successText {
+  @apply text-green-600 dark:text-green-400;
+}
+
+.updateText {
+  @apply text-yellow-600 dark:text-yellow-400;
+}
+
+.resultContainer {
+  @apply text-sm py-2 space-y-1;
+}
+
+.resultCard {
+  @apply text-sm py-2 rounded-lg bg-muted/50 px-3;
+}
+
+.resultHeader {
+  @apply flex items-center gap-2 text-muted-foreground;
+}
+
+.resultHeaderWithMargin {
+  @apply flex items-center gap-2 text-muted-foreground mb-2;
+}
+
+.statsGrid {
+  @apply grid grid-cols-3 gap-2 text-center;
+}
+
+.statValue {
+  @apply text-lg font-semibold;
+}
+
+.statLabel {
+  @apply text-xs text-muted-foreground;
+}
+
+.moodDistribution {
+  @apply flex items-center gap-3 flex-wrap;
+}
+
+.moodItem {
+  @apply flex items-center gap-1;
+}
+
+.moodPercent {
+  @apply text-xs text-muted-foreground;
+}
+
+.noDataText {
+  @apply text-xs text-muted-foreground;
+}

--- a/src/components/chat/ToolInvocationDisplay/ToolInvocationDisplay.module.css
+++ b/src/components/chat/ToolInvocationDisplay/ToolInvocationDisplay.module.css
@@ -1,4 +1,4 @@
-@reference "../../../styles/app.css";
+@reference "~/styles/app.css";
 
 .statusRow {
   @apply flex items-center gap-2 text-sm py-2;

--- a/src/components/chat/ToolInvocationDisplay/ToolInvocationDisplay.tsx
+++ b/src/components/chat/ToolInvocationDisplay/ToolInvocationDisplay.tsx
@@ -21,6 +21,7 @@ import {
   MOOD_SCALE,
   type MoodLevel,
 } from "~/features/journal";
+import styles from "./ToolInvocationDisplay.module.css";
 
 interface Props {
   part: ToolUIPart;
@@ -40,8 +41,8 @@ export function ToolInvocationDisplay({ part }: Props) {
   // Loading state
   if (isLoading) {
     return (
-      <div className="flex items-center gap-2 text-sm text-muted-foreground py-2">
-        <Loader2 className="size-4 animate-spin" />
+      <div className={`${styles.statusRow} ${styles.loadingText}`}>
+        <Loader2 className={styles.spinningIcon} />
         <span>{config.label}...</span>
       </div>
     );
@@ -50,8 +51,8 @@ export function ToolInvocationDisplay({ part }: Props) {
   // Error state
   if (hasError) {
     return (
-      <div className="flex items-center gap-2 text-sm py-2 text-red-500">
-        <AlertCircle className="size-4" />
+      <div className={`${styles.statusRow} ${styles.errorText}`}>
+        <AlertCircle className={styles.icon} />
         <span>
           {config.label} failed: {part.errorText || "Unknown error"}
         </span>
@@ -63,15 +64,15 @@ export function ToolInvocationDisplay({ part }: Props) {
   if (toolName === "create_journal_entry" && isSaveEntryResult(result)) {
     if (result.success) {
       return (
-        <div className="flex items-center gap-2 text-sm py-2 text-green-600 dark:text-green-400">
-          <Check className="size-4" />
+        <div className={`${styles.statusRow} ${styles.successText}`}>
+          <Check className={styles.icon} />
           <span>Entry saved</span>
         </div>
       );
     }
     return (
-      <div className="flex items-center gap-2 text-sm py-2 text-red-500">
-        <AlertCircle className="size-4" />
+      <div className={`${styles.statusRow} ${styles.errorText}`}>
+        <AlertCircle className={styles.icon} />
         <span>Failed to save: {result.error}</span>
       </div>
     );
@@ -81,15 +82,15 @@ export function ToolInvocationDisplay({ part }: Props) {
   if (toolName === "update_journal_entry" && isSaveEntryResult(result)) {
     if (result.success) {
       return (
-        <div className="flex items-center gap-2 text-sm py-2 text-yellow-600 dark:text-yellow-400">
-          <Check className="size-4" />
+        <div className={`${styles.statusRow} ${styles.updateText}`}>
+          <Check className={styles.icon} />
           <span>Entry updated</span>
         </div>
       );
     }
     return (
-      <div className="flex items-center gap-2 text-sm py-2 text-red-500">
-        <AlertCircle className="size-4" />
+      <div className={`${styles.statusRow} ${styles.errorText}`}>
+        <AlertCircle className={styles.icon} />
         <span>Failed to update: {result.error}</span>
       </div>
     );
@@ -99,17 +100,17 @@ export function ToolInvocationDisplay({ part }: Props) {
   if (toolName === "get_recent_entries" && isRecentEntriesResult(result)) {
     if (result.success && result.entries?.length) {
       return (
-        <div className="text-sm py-2 space-y-1">
-          <div className="flex items-center gap-2 text-muted-foreground">
-            <Calendar className="size-4" />
+        <div className={styles.resultContainer}>
+          <div className={styles.resultHeader}>
+            <Calendar className={styles.icon} />
             <span>Found {result.count} recent entries</span>
           </div>
         </div>
       );
     }
     return (
-      <div className="flex items-center gap-2 text-sm py-2 text-muted-foreground">
-        <Calendar className="size-4" />
+      <div className={`${styles.statusRow} ${styles.loadingText}`}>
+        <Calendar className={styles.icon} />
         <span>No recent entries found</span>
       </div>
     );
@@ -119,9 +120,9 @@ export function ToolInvocationDisplay({ part }: Props) {
   if (toolName === "search_entries" && isSearchResult(result)) {
     if (result.success) {
       return (
-        <div className="text-sm py-2 space-y-1">
-          <div className="flex items-center gap-2 text-muted-foreground">
-            <Search className="size-4" />
+        <div className={styles.resultContainer}>
+          <div className={styles.resultHeader}>
+            <Search className={styles.icon} />
             <span>Found {result.count} matching entries</span>
           </div>
         </div>
@@ -133,9 +134,9 @@ export function ToolInvocationDisplay({ part }: Props) {
   if (toolName === "get_entries_by_tag" && isEntriesByTagResult(result)) {
     if (result.success) {
       return (
-        <div className="text-sm py-2 space-y-1">
-          <div className="flex items-center gap-2 text-muted-foreground">
-            <Tag className="size-4" />
+        <div className={styles.resultContainer}>
+          <div className={styles.resultHeader}>
+            <Tag className={styles.icon} />
             <span>
               Found {result.count} entries tagged <strong>#{result.tag}</strong>
             </span>
@@ -152,24 +153,24 @@ export function ToolInvocationDisplay({ part }: Props) {
       const total = Object.values(distribution).reduce((a, b) => a + b, 0);
 
       return (
-        <div className="text-sm py-2 rounded-lg bg-muted/50 px-3">
-          <div className="flex items-center gap-2 text-muted-foreground mb-2">
-            <TrendingUp className="size-4" />
+        <div className={styles.resultCard}>
+          <div className={styles.resultHeaderWithMargin}>
+            <TrendingUp className={styles.icon} />
             <span>Mood trends ({result.period_days} days)</span>
           </div>
-          <div className="flex items-center gap-3 flex-wrap">
+          <div className={styles.moodDistribution}>
             {(Object.entries(distribution) as [MoodLevel, number][])
               .filter(([, count]) => count > 0)
               .map(([mood, count]) => (
-                <div key={mood} className="flex items-center gap-1">
+                <div key={mood} className={styles.moodItem}>
                   <span>{MOOD_SCALE[mood].emoji}</span>
-                  <span className="text-xs text-muted-foreground">
+                  <span className={styles.moodPercent}>
                     {Math.round((count / total) * 100)}%
                   </span>
                 </div>
               ))}
           </div>
-          {total === 0 && <div className="text-xs text-muted-foreground">No mood data yet</div>}
+          {total === 0 && <div className={styles.noDataText}>No mood data yet</div>}
         </div>
       );
     }
@@ -179,23 +180,23 @@ export function ToolInvocationDisplay({ part }: Props) {
   if (toolName === "get_entry_stats" && isStatsResult(result)) {
     if (result.success) {
       return (
-        <div className="text-sm py-2 rounded-lg bg-muted/50 px-3">
-          <div className="flex items-center gap-2 text-muted-foreground mb-2">
-            <BarChart3 className="size-4" />
+        <div className={styles.resultCard}>
+          <div className={styles.resultHeaderWithMargin}>
+            <BarChart3 className={styles.icon} />
             <span>Your journaling stats ({result.period})</span>
           </div>
-          <div className="grid grid-cols-3 gap-2 text-center">
+          <div className={styles.statsGrid}>
             <div>
-              <div className="text-lg font-semibold">{result.total_entries}</div>
-              <div className="text-xs text-muted-foreground">entries</div>
+              <div className={styles.statValue}>{result.total_entries}</div>
+              <div className={styles.statLabel}>entries</div>
             </div>
             <div>
-              <div className="text-lg font-semibold">{result.streak_days}</div>
-              <div className="text-xs text-muted-foreground">day streak</div>
+              <div className={styles.statValue}>{result.streak_days}</div>
+              <div className={styles.statLabel}>day streak</div>
             </div>
             <div>
-              <div className="text-lg font-semibold">{result.avg_entry_length}</div>
-              <div className="text-xs text-muted-foreground">avg chars</div>
+              <div className={styles.statValue}>{result.avg_entry_length}</div>
+              <div className={styles.statLabel}>avg chars</div>
             </div>
           </div>
         </div>
@@ -205,8 +206,8 @@ export function ToolInvocationDisplay({ part }: Props) {
 
   // Fallback
   return (
-    <div className="flex items-center gap-2 text-sm py-2 text-muted-foreground">
-      <Icon className={cn("size-4", config.color)} />
+    <div className={`${styles.statusRow} ${styles.loadingText}`}>
+      <Icon className={cn(styles.icon, config.color)} />
       <span>{config.label} complete</span>
     </div>
   );

--- a/src/components/chat/ToolInvocationDisplay/ToolInvocationDisplay.tsx
+++ b/src/components/chat/ToolInvocationDisplay/ToolInvocationDisplay.tsx
@@ -164,9 +164,7 @@ export function ToolInvocationDisplay({ part }: Props) {
               .map(([mood, count]) => (
                 <div key={mood} className={styles.moodItem}>
                   <span>{MOOD_SCALE[mood].emoji}</span>
-                  <span className={styles.moodPercent}>
-                    {Math.round((count / total) * 100)}%
-                  </span>
+                  <span className={styles.moodPercent}>{Math.round((count / total) * 100)}%</span>
                 </div>
               ))}
           </div>

--- a/src/components/chat/ToolInvocationDisplay/index.ts
+++ b/src/components/chat/ToolInvocationDisplay/index.ts
@@ -1,0 +1,1 @@
+export { ToolInvocationDisplay } from "./ToolInvocationDisplay";

--- a/src/components/layout/AppLayout/AppLayout.module.css
+++ b/src/components/layout/AppLayout/AppLayout.module.css
@@ -1,0 +1,21 @@
+@reference "../../../styles/app.css";
+
+.inset {
+  @apply h-screen overflow-hidden;
+}
+
+.header {
+  @apply flex h-12 shrink-0 items-center gap-2 border-b border-border px-4;
+}
+
+.separator {
+  @apply mr-2;
+}
+
+.title {
+  @apply text-sm font-medium;
+}
+
+.main {
+  @apply flex-1 h-full overflow-auto;
+}

--- a/src/components/layout/AppLayout/AppLayout.module.css
+++ b/src/components/layout/AppLayout/AppLayout.module.css
@@ -1,4 +1,4 @@
-@reference "../../../styles/app.css";
+@reference "~/styles/app.css";
 
 .inset {
   @apply h-screen overflow-hidden;

--- a/src/components/layout/AppLayout/AppLayout.tsx
+++ b/src/components/layout/AppLayout/AppLayout.tsx
@@ -1,8 +1,9 @@
 import { Outlet, useRouterState } from "@tanstack/react-router";
 import { SidebarInset, SidebarProvider, SidebarTrigger, useSidebar } from "~/components/ui/sidebar";
-import { AppSidebar } from "./AppSidebar";
+import { AppSidebar } from "../AppSidebar";
 import { Separator } from "~/components/ui/separator";
 import { useEffect } from "react";
+import styles from "./AppLayout.module.css";
 
 function AppLayoutContent() {
   const router = useRouterState();
@@ -17,13 +18,13 @@ function AppLayoutContent() {
   return (
     <>
       <AppSidebar />
-      <SidebarInset className="h-screen overflow-hidden">
-        <header className="flex h-12 shrink-0 items-center gap-2 border-b border-border px-4">
+      <SidebarInset className={styles.inset}>
+        <header className={styles.header}>
           <SidebarTrigger />
-          <Separator orientation="vertical" className="mr-2" />
-          <span className="text-sm font-medium">Journal Assistant</span>
+          <Separator orientation="vertical" className={styles.separator} />
+          <span className={styles.title}>Journal Assistant</span>
         </header>
-        <main className="flex-1 h-full overflow-auto">
+        <main className={styles.main}>
           <Outlet />
         </main>
       </SidebarInset>

--- a/src/components/layout/AppLayout/index.ts
+++ b/src/components/layout/AppLayout/index.ts
@@ -1,0 +1,1 @@
+export { AppLayout } from "./AppLayout";

--- a/src/components/layout/AppSidebar/AppSidebar.module.css
+++ b/src/components/layout/AppSidebar/AppSidebar.module.css
@@ -1,4 +1,4 @@
-@reference "../../../styles/app.css";
+@reference "~/styles/app.css";
 
 .headerContainer {
   @apply h-12 flex items-center;

--- a/src/components/layout/AppSidebar/AppSidebar.module.css
+++ b/src/components/layout/AppSidebar/AppSidebar.module.css
@@ -1,0 +1,29 @@
+@reference "../../../styles/app.css";
+
+.headerContainer {
+  @apply h-12 flex items-center;
+}
+
+.logoContainer {
+  @apply flex items-center gap-2 px-2;
+}
+
+.logoIcon {
+  @apply size-5;
+}
+
+.logoText {
+  @apply font-semibold;
+}
+
+.navIcon {
+  @apply size-4;
+}
+
+.placeholder {
+  @apply px-2 text-xs text-muted-foreground;
+}
+
+.logoutButton {
+  @apply cursor-pointer;
+}

--- a/src/components/layout/AppSidebar/AppSidebar.tsx
+++ b/src/components/layout/AppSidebar/AppSidebar.tsx
@@ -12,6 +12,7 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from "~/components/ui/sidebar";
+import styles from "./AppSidebar.module.css";
 
 const navItems = [
   { to: "/chat", icon: MessageSquare, label: "Chat" },
@@ -24,10 +25,10 @@ export function AppSidebar() {
 
   return (
     <Sidebar>
-      <SidebarHeader className="h-12 flex items-center">
-        <div className="flex items-center gap-2 px-2">
-          <BookOpen className="size-5" />
-          <span className="font-semibold">Journal</span>
+      <SidebarHeader className={styles.headerContainer}>
+        <div className={styles.logoContainer}>
+          <BookOpen className={styles.logoIcon} />
+          <span className={styles.logoText}>Journal</span>
         </div>
       </SidebarHeader>
 
@@ -41,7 +42,7 @@ export function AppSidebar() {
                 return (
                   <SidebarMenuItem key={item.to}>
                     <SidebarMenuButton isActive={!!isActive} render={<Link to={item.to} />}>
-                      <item.icon className="size-4" />
+                      <item.icon className={styles.navIcon} />
                       <span>{item.label}</span>
                     </SidebarMenuButton>
                   </SidebarMenuItem>
@@ -55,7 +56,7 @@ export function AppSidebar() {
         <SidebarGroup>
           <SidebarGroupLabel>History</SidebarGroupLabel>
           <SidebarGroupContent>
-            <p className="px-2 text-xs text-muted-foreground">Coming in Phase 3</p>
+            <p className={styles.placeholder}>Coming in Phase 3</p>
           </SidebarGroupContent>
         </SidebarGroup>
       </SidebarContent>
@@ -67,9 +68,9 @@ export function AppSidebar() {
               onClick={() => {
                 router.navigate({ to: "/logout" });
               }}
-              className="cursor-pointer"
+              className={styles.logoutButton}
             >
-              <LogOut className="size-4" />
+              <LogOut className={styles.navIcon} />
               <span>Logout</span>
             </SidebarMenuButton>
           </SidebarMenuItem>

--- a/src/components/layout/AppSidebar/index.ts
+++ b/src/components/layout/AppSidebar/index.ts
@@ -1,0 +1,1 @@
+export { AppSidebar } from "./AppSidebar";

--- a/src/routes/_authed/chat.module.css
+++ b/src/routes/_authed/chat.module.css
@@ -1,4 +1,4 @@
-@reference "../../styles/app.css";
+@reference "~/styles/app.css";
 
 .container {
   @apply grid grid-rows-[1fr_auto] h-full overflow-hidden;

--- a/src/routes/_authed/chat.module.css
+++ b/src/routes/_authed/chat.module.css
@@ -1,0 +1,41 @@
+@reference "../../styles/app.css";
+
+.container {
+  @apply grid grid-rows-[1fr_auto] h-full overflow-hidden;
+}
+
+.messagesScroll {
+  @apply overflow-y-auto;
+}
+
+.emptyState {
+  @apply flex flex-col items-center justify-center h-full text-center px-4;
+}
+
+.emptyContent {
+  @apply max-w-md space-y-3;
+}
+
+.emptyTitle {
+  @apply text-2xl font-semibold;
+}
+
+.emptyDescription {
+  @apply text-muted-foreground;
+}
+
+.messagesContainer {
+  @apply max-w-3xl mx-auto px-4 py-6 space-y-4;
+}
+
+.messageBubble {
+  @apply rounded-lg px-4 py-3 max-w-prose;
+}
+
+.userMessage {
+  @apply bg-primary text-primary-foreground ml-auto;
+}
+
+.assistantMessage {
+  @apply bg-muted text-foreground;
+}

--- a/src/routes/_authed/chat.tsx
+++ b/src/routes/_authed/chat.tsx
@@ -8,6 +8,7 @@ import { ChatInput } from "~/components/chat/ChatInput";
 import { useQueryClient } from "@tanstack/react-query";
 import ReactMarkdown from "react-markdown";
 import { useEffect, useRef } from "react";
+import styles from "./chat.module.css";
 
 export const Route = createFileRoute("/_authed/chat")({
   component: Chat,
@@ -34,14 +35,14 @@ function Chat() {
   }, [messages]);
 
   return (
-    <div className="grid grid-rows-[1fr_auto] h-full overflow-hidden">
+    <div className={styles.container}>
       {/* Messages */}
-      <div className="overflow-y-auto">
+      <div className={styles.messagesScroll}>
         {messages.length === 0 ? (
-          <div className="flex flex-col items-center justify-center h-full text-center px-4">
-            <div className="max-w-md space-y-3">
-              <h2 className="text-2xl font-semibold">Welcome to Journal Chatbot</h2>
-              <p className="text-muted-foreground">
+          <div className={styles.emptyState}>
+            <div className={styles.emptyContent}>
+              <h2 className={styles.emptyTitle}>Welcome to Journal Chatbot</h2>
+              <p className={styles.emptyDescription}>
                 Start a conversation with your AI-powered journal assistant. Share your thoughts,
                 reflect on your day, or explore ideas.
               </p>
@@ -49,15 +50,15 @@ function Chat() {
             </div>
           </div>
         ) : (
-          <div className="max-w-3xl mx-auto px-4 py-6 space-y-4">
+          <div className={styles.messagesContainer}>
             {messages.map((message) => (
               <div key={message.id}>
                 <div
                   className={cn(
-                    "rounded-lg px-4 py-3 max-w-prose",
+                    styles.messageBubble,
                     message.role === "user"
-                      ? "bg-primary text-primary-foreground ml-auto"
-                      : "bg-muted text-foreground",
+                      ? styles.userMessage
+                      : styles.assistantMessage,
                   )}
                 >
                   {message.parts.map((part, i) => {

--- a/src/routes/_authed/chat.tsx
+++ b/src/routes/_authed/chat.tsx
@@ -56,9 +56,7 @@ function Chat() {
                 <div
                   className={cn(
                     styles.messageBubble,
-                    message.role === "user"
-                      ? styles.userMessage
-                      : styles.assistantMessage,
+                    message.role === "user" ? styles.userMessage : styles.assistantMessage,
                   )}
                 >
                   {message.parts.map((part, i) => {

--- a/src/routes/_authed/entries.module.css
+++ b/src/routes/_authed/entries.module.css
@@ -1,4 +1,4 @@
-@reference "../../styles/app.css";
+@reference "~/styles/app.css";
 
 .centered {
   @apply flex items-center justify-center h-full;

--- a/src/routes/_authed/entries.module.css
+++ b/src/routes/_authed/entries.module.css
@@ -1,0 +1,81 @@
+@reference "../../styles/app.css";
+
+.centered {
+  @apply flex items-center justify-center h-full;
+}
+
+.centeredColumn {
+  @apply flex flex-col items-center justify-center h-full text-center px-4;
+}
+
+.contentBox {
+  @apply max-w-md space-y-3;
+}
+
+.pageTitle {
+  @apply text-2xl font-semibold;
+}
+
+.mutedText {
+  @apply text-muted-foreground;
+}
+
+.errorText {
+  @apply text-destructive;
+}
+
+.pageContainer {
+  @apply flex flex-col h-full;
+}
+
+.pageHeader {
+  @apply border-b border-border px-6 py-4;
+}
+
+.entryCount {
+  @apply text-sm text-muted-foreground mt-1;
+}
+
+.entriesScroll {
+  @apply flex-1 overflow-y-auto px-6 py-4;
+}
+
+.entriesContainer {
+  @apply max-w-4xl space-y-3;
+}
+
+.entryCard {
+  @apply p-4 hover:bg-accent/50 transition-colors cursor-pointer;
+}
+
+.entryRow {
+  @apply flex items-start gap-3;
+}
+
+.moodEmoji {
+  @apply text-2xl flex-shrink-0;
+}
+
+.entryContent {
+  @apply flex-1 min-w-0;
+}
+
+.entryDate {
+  @apply text-sm text-muted-foreground mb-1;
+}
+
+.entrySummary {
+  @apply font-medium mb-2 line-clamp-1;
+}
+
+.entryPreview {
+  @apply text-sm text-muted-foreground line-clamp-2 mb-2;
+}
+
+.tagsContainer {
+  @apply flex flex-wrap gap-1;
+}
+
+.tag {
+  @apply text-xs;
+}

--- a/src/routes/_authed/entries.tsx
+++ b/src/routes/_authed/entries.tsx
@@ -77,19 +77,13 @@ function Entries() {
 
                 <div className={styles.entryContent}>
                   {/* Date */}
-                  <div className={styles.entryDate}>
-                    {formatDate(entry.entry_date)}
-                  </div>
+                  <div className={styles.entryDate}>{formatDate(entry.entry_date)}</div>
 
                   {/* Summary */}
-                  {entry.summary && (
-                    <div className={styles.entrySummary}>{entry.summary}</div>
-                  )}
+                  {entry.summary && <div className={styles.entrySummary}>{entry.summary}</div>}
 
                   {/* Content preview */}
-                  <div className={styles.entryPreview}>
-                    {stripMarkdown(entry.content)}
-                  </div>
+                  <div className={styles.entryPreview}>{stripMarkdown(entry.content)}</div>
 
                   {/* Tags */}
                   {entry.tags && entry.tags.length > 0 && (

--- a/src/routes/_authed/entries.tsx
+++ b/src/routes/_authed/entries.tsx
@@ -7,6 +7,7 @@ import { stripMarkdown } from "~/lib/utils";
 import { Card } from "~/components/ui/card";
 import { Badge } from "~/components/ui/badge";
 import { EntryDetailSheet } from "~/features/journal/components/EntryDetailSheet";
+import styles from "./entries.module.css";
 
 const entriesSearchSchema = z.object({
   entryId: z.string().optional(),
@@ -24,26 +25,26 @@ function Entries() {
 
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center h-full">
-        <p className="text-muted-foreground">Loading entries...</p>
+      <div className={styles.centered}>
+        <p className={styles.mutedText}>Loading entries...</p>
       </div>
     );
   }
 
   if (error) {
     return (
-      <div className="flex items-center justify-center h-full">
-        <p className="text-destructive">Error loading entries: {error.message}</p>
+      <div className={styles.centered}>
+        <p className={styles.errorText}>Error loading entries: {error.message}</p>
       </div>
     );
   }
 
   if (!entries || entries.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center h-full text-center px-4">
-        <div className="max-w-md space-y-3">
-          <h2 className="text-2xl font-semibold">No entries yet</h2>
-          <p className="text-muted-foreground">
+      <div className={styles.centeredColumn}>
+        <div className={styles.contentBox}>
+          <h2 className={styles.pageTitle}>No entries yet</h2>
+          <p className={styles.mutedText}>
             Start journaling by chatting with your AI assistant or create an entry here.
           </p>
         </div>
@@ -52,49 +53,49 @@ function Entries() {
   }
 
   return (
-    <div className="flex flex-col h-full">
-      <div className="border-b border-border px-6 py-4">
-        <h1 className="text-2xl font-semibold">Journal Entries</h1>
-        <p className="text-sm text-muted-foreground mt-1">{entries.length} total entries</p>
+    <div className={styles.pageContainer}>
+      <div className={styles.pageHeader}>
+        <h1 className={styles.pageTitle}>Journal Entries</h1>
+        <p className={styles.entryCount}>{entries.length} total entries</p>
       </div>
 
-      <div className="flex-1 overflow-y-auto px-6 py-4">
-        <div className="max-w-4xl space-y-3">
+      <div className={styles.entriesScroll}>
+        <div className={styles.entriesContainer}>
           {entries.map((entry) => (
             <Card
               key={entry.id}
-              className="p-4 hover:bg-accent/50 transition-colors cursor-pointer"
+              className={styles.entryCard}
               onClick={() => navigate({ to: "/entries", search: { entryId: entry.id } })}
             >
-              <div className="flex items-start gap-3">
+              <div className={styles.entryRow}>
                 {/* Mood emoji */}
                 {entry.mood && (
-                  <div className="text-2xl flex-shrink-0" title={getMoodConfig(entry.mood).label}>
+                  <div className={styles.moodEmoji} title={getMoodConfig(entry.mood).label}>
                     {getMoodConfig(entry.mood).emoji}
                   </div>
                 )}
 
-                <div className="flex-1 min-w-0">
+                <div className={styles.entryContent}>
                   {/* Date */}
-                  <div className="text-sm text-muted-foreground mb-1">
+                  <div className={styles.entryDate}>
                     {formatDate(entry.entry_date)}
                   </div>
 
                   {/* Summary */}
                   {entry.summary && (
-                    <div className="font-medium mb-2 line-clamp-1">{entry.summary}</div>
+                    <div className={styles.entrySummary}>{entry.summary}</div>
                   )}
 
                   {/* Content preview */}
-                  <div className="text-sm text-muted-foreground line-clamp-2 mb-2">
+                  <div className={styles.entryPreview}>
                     {stripMarkdown(entry.content)}
                   </div>
 
                   {/* Tags */}
                   {entry.tags && entry.tags.length > 0 && (
-                    <div className="flex flex-wrap gap-1">
+                    <div className={styles.tagsContainer}>
                       {entry.tags.map((tag) => (
-                        <Badge key={tag} variant="secondary" className="text-xs">
+                        <Badge key={tag} variant="secondary" className={styles.tag}>
                           {tag}
                         </Badge>
                       ))}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,6 @@
 import { tanstackStart } from "@tanstack/react-start/plugin/vite";
 import { defineConfig } from "vite";
+import path from "path";
 import tsConfigPaths from "vite-tsconfig-paths";
 import viteReact from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
@@ -8,6 +9,11 @@ import { cloudflare } from "@cloudflare/vite-plugin";
 export default defineConfig({
   server: {
     port: 3000,
+  },
+  resolve: {
+    alias: {
+      "~": path.resolve(__dirname, "./src"),
+    },
   },
   plugins: [
     tailwindcss(),


### PR DESCRIPTION
## Summary
Migrated inline Tailwind utility classes to CSS modules with `@apply` directive for all custom components and route files. Reorganized components into folder structure with dedicated module files and barrel exports.

## Rationale
- **Separation of concerns**: Styles are now in dedicated CSS files rather than mixed with JSX
- **Maintainability**: Easier to find and update styles without searching through component logic
- **Semantic naming**: Class names like `.container`, `.header`, `.actionButton` provide better context than utility classes
- **Reusability**: CSS module classes can be composed and shared more easily

## Changes
**Components refactored (8 files → folders):**
- `NotFound.tsx` → `NotFound/` (with `.module.css` + `index.ts`)
- `DefaultCatchBoundary.tsx` → `DefaultCatchBoundary/`
- `PromptPresets.tsx` → `chat/PromptPresets/`
- `ChatInput.tsx` → `chat/ChatInput/`
- `AppLayout.tsx` → `layout/AppLayout/`
- `AppSidebar.tsx` → `layout/AppSidebar/`
- `LoginForm.tsx` → `LoginForm/`
- `ToolInvocationDisplay.tsx` → `chat/ToolInvocationDisplay/`

**Routes with CSS modules added (2 files):**
- `src/routes/_authed/entries.tsx` + `entries.module.css`
- `src/routes/_authed/chat.tsx` + `chat.module.css`

**Technical details:**
- All CSS modules use `@reference "~/styles/app.css"` directive for Tailwind v4 compatibility
- Added explicit `~` alias to vite resolve config for CSS module imports
- Semantic class naming convention (`.container`, `.header`, `.actionButton`, etc.)
- Dynamic classes preserved using `cn()` utility (message bubbles, conditional styling)
- Barrel exports via `index.ts` files maintain existing import paths
- Documentation added to `CLAUDE.md` with CSS module guidelines

## Impact
- **No breaking changes**: All imports work via barrel exports
- **Build verification**: Production build passes successfully
- **Code organization**: Cleaner component structure with dedicated style files
- **Developer experience**: Easier to maintain and update styles independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)